### PR TITLE
Fix Bug Duplicate black Money

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -495,7 +495,7 @@ function OpenBodySearchMenu(player)
 		}, function(data, menu)
 			if data.current.value then
 				TriggerServerEvent('esx_policejob:confiscatePlayerItem', GetPlayerServerId(player), data.current.itemType, data.current.value, data.current.amount)
-				OpenBodySearchMenu(player)
+				menu.close()
 			end
 		end, function(data, menu)
 			menu.close()


### PR DESCRIPTION
This error consists in that when the black money is confiscated (if it is given twice quickly) the money is doubled and the objective remains in negative money.
I know that many use the esx_policejob as the basis for the esx_mafia therefore, this error is very important to solve, since if the money is added together with the black_money it can be duplicated in a phenomenal way.

Sorry for my English, I tried to explain myself what else I could.