### PR TITLE
even better way to fix bug with duplicating money and weapons

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -495,7 +495,7 @@ function OpenBodySearchMenu(player)
 		}, function(data, menu)
 			if data.current.value then
 				TriggerServerEvent('esx_policejob:confiscatePlayerItem', GetPlayerServerId(player), data.current.itemType, data.current.value, data.current.amount)
-				menu.close()
+				OpenBodySearchMenu(player)
 			end
 		end, function(data, menu)
 			menu.close()

--- a/server/main.lua
+++ b/server/main.lua
@@ -43,19 +43,32 @@ AddEventHandler('esx_policejob:confiscatePlayerItem', function(target, itemType,
 		end
 
 	elseif itemType == 'item_account' then
-		targetXPlayer.removeAccountMoney(itemName, amount)
-		sourceXPlayer.addAccountMoney   (itemName, amount)
+		local targetAccount = targetXPlayer.getAccount(itemName)
 
-		sourceXPlayer.showNotification(_U('you_confiscated_account', amount, itemName, targetXPlayer.name))
-		targetXPlayer.showNotification(_U('got_confiscated_account', amount, itemName, sourceXPlayer.name))
+		-- does the target player have enough money?
+		if targetAccount.money >= amount then
+			targetXPlayer.removeAccountMoney(itemName, amount)
+			sourceXPlayer.addAccountMoney   (itemName, amount)
+
+			sourceXPlayer.showNotification(_U('you_confiscated_account', amount, itemName, targetXPlayer.name))
+			targetXPlayer.showNotification(_U('got_confiscated_account', amount, itemName, sourceXPlayer.name))
+		else
+			sourceXPlayer.showNotification(_U('quantity_invalid'))
+		end
 
 	elseif itemType == 'item_weapon' then
 		if amount == nil then amount = 0 end
-		targetXPlayer.removeWeapon(itemName, amount)
-		sourceXPlayer.addWeapon   (itemName, amount)
 
-		sourceXPlayer.showNotification(_U('you_confiscated_weapon', ESX.GetWeaponLabel(itemName), targetXPlayer.name, amount))
-		targetXPlayer.showNotification(_U('got_confiscated_weapon', ESX.GetWeaponLabel(itemName), amount, sourceXPlayer.name))
+		-- does the target player have weapon?
+		if targetXPlayer.hasWeapon(itemName) then
+			targetXPlayer.removeWeapon(itemName, amount)
+			sourceXPlayer.addWeapon   (itemName, amount)
+
+			sourceXPlayer.showNotification(_U('you_confiscated_weapon', ESX.GetWeaponLabel(itemName), targetXPlayer.name, amount))
+			targetXPlayer.showNotification(_U('got_confiscated_weapon', ESX.GetWeaponLabel(itemName), amount, sourceXPlayer.name))
+		else
+			sourceXPlayer.showNotification(_U('quantity_invalid'))
+		end
 	end
 end)
 


### PR DESCRIPTION
In my solution, I check if player has weapon/money that officers might want to take server-side. Previous solutions were vulnerable e.g. if two or more officers were searching one player and all took weapon or money at the same time, they would all get that items.